### PR TITLE
2단계 InheritedWidget 사용하기

### DIFF
--- a/lib/cart/cart_screen.dart
+++ b/lib/cart/cart_screen.dart
@@ -32,6 +32,18 @@ class _CartScreenState extends State<CartScreen> {
 
   int _counter = 1;
 
+  void _incrementCounter() {
+    setState(() {
+      _counter++;
+    });
+  }
+
+  void _decrementCounter() {
+    setState(() {
+      _counter--;
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -60,7 +72,10 @@ class _CartScreenState extends State<CartScreen> {
             SizedBox(
               height: 1,
             ),
-            MenuWidget(_menu),
+            MenuWidget(
+                menu: _menu,
+                incrementCounter: _incrementCounter,
+                decrementCounter: _decrementCounter),
             SizedBox(
               height: 1,
             ),

--- a/lib/cart/cart_screen.dart
+++ b/lib/cart/cart_screen.dart
@@ -69,3 +69,25 @@ class _CartScreenState extends State<CartScreen> {
     );
   }
 }
+
+class Counter extends InheritedWidget {
+  const Counter({
+    Key? key,
+    required this.value,
+    required Widget child,
+  }) : super(key: key, child: child);
+
+  final int value;
+
+  static Counter of(BuildContext context) {
+    final Counter? result =
+        context.dependOnInheritedWidgetOfExactType<Counter>();
+    assert(result != null, 'No Counter found in context');
+    return result!;
+  }
+
+  @override
+  bool updateShouldNotify(Counter old) {
+    return old.value != value;
+  }
+}

--- a/lib/cart/cart_screen.dart
+++ b/lib/cart/cart_screen.dart
@@ -86,7 +86,11 @@ class _CartScreenState extends State<CartScreen> {
           ],
         ),
       ),
-      bottomNavigationBar: _OrderButtonWidget(_menu.price + _deliveryPrice),
+      bottomNavigationBar: _OrderButtonWidget(
+        counter: _counter,
+        deliveryPrice: _deliveryPrice,
+        itemPrice: _menu.price,
+      ),
     );
   }
 }

--- a/lib/cart/cart_screen.dart
+++ b/lib/cart/cart_screen.dart
@@ -30,6 +30,8 @@ class _CartScreenState extends State<CartScreen> {
 
   final _billing = Billing(totalPrice: 18000, deliveryPrice: 3000);
 
+  int _counter = 1;
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -47,22 +49,25 @@ class _CartScreenState extends State<CartScreen> {
         elevation: 0,
         backgroundColor: Colors.white,
       ),
-      body: ListView(
-        children: [
-          SizedBox(
-            height: 10,
-          ),
-          StoreNameWidget(_storeData),
-          SizedBox(
-            height: 1,
-          ),
-          MenuWidget(_menu),
-          SizedBox(
-            height: 1,
-          ),
-          AddMoreWidget(),
-          BillingWidget(_billing),
-        ],
+      body: Counter(
+        value: _counter,
+        child: ListView(
+          children: [
+            SizedBox(
+              height: 10,
+            ),
+            StoreNameWidget(_storeData),
+            SizedBox(
+              height: 1,
+            ),
+            MenuWidget(_menu),
+            SizedBox(
+              height: 1,
+            ),
+            AddMoreWidget(),
+            BillingWidget(_billing),
+          ],
+        ),
       ),
       bottomNavigationBar:
           _OrderButtonWidget(_billing.deliveryPrice + _billing.totalPrice),

--- a/lib/cart/cart_screen.dart
+++ b/lib/cart/cart_screen.dart
@@ -45,53 +45,51 @@ class _CartScreenState extends State<CartScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: const Color.fromRGBO(246, 246, 246, 1.0),
-      appBar: AppBar(
-        leading: const BackButton(
-          color: Colors.black,
-        ),
-        title: const Text(
-          '장바구니',
-          style: TextStyle(
-            color: Colors.black,
-          ),
-        ),
-        elevation: 0,
-        backgroundColor: Colors.white,
-      ),
-      body: Counter(
+    return Counter(
         value: _counter,
-        child: ListView(
-          children: [
-            SizedBox(
-              height: 10,
+        child: Scaffold(
+          backgroundColor: const Color.fromRGBO(246, 246, 246, 1.0),
+          appBar: AppBar(
+            leading: const BackButton(
+              color: Colors.black,
             ),
-            StoreNameWidget(_storeData),
-            SizedBox(
-              height: 1,
+            title: const Text(
+              '장바구니',
+              style: TextStyle(
+                color: Colors.black,
+              ),
             ),
-            MenuWidget(
-                menu: _menu,
-                incrementCounter: _incrementCounter,
-                decrementCounter: _decrementCounter),
-            SizedBox(
-              height: 1,
-            ),
-            AddMoreWidget(),
-            BillingWidget(
-              deliveryPrice: _deliveryPrice,
-              itemPrice: _menu.price,
-            ),
-          ],
-        ),
-      ),
-      bottomNavigationBar: _OrderButtonWidget(
-        counter: _counter,
-        deliveryPrice: _deliveryPrice,
-        itemPrice: _menu.price,
-      ),
-    );
+            elevation: 0,
+            backgroundColor: Colors.white,
+          ),
+          body: ListView(
+            children: [
+              SizedBox(
+                height: 10,
+              ),
+              StoreNameWidget(_storeData),
+              SizedBox(
+                height: 1,
+              ),
+              MenuWidget(
+                  menu: _menu,
+                  incrementCounter: _incrementCounter,
+                  decrementCounter: _decrementCounter),
+              SizedBox(
+                height: 1,
+              ),
+              AddMoreWidget(),
+              BillingWidget(
+                deliveryPrice: _deliveryPrice,
+                itemPrice: _menu.price,
+              ),
+            ],
+          ),
+          bottomNavigationBar: _OrderButtonWidget(
+            deliveryPrice: _deliveryPrice,
+            itemPrice: _menu.price,
+          ),
+        ));
   }
 }
 

--- a/lib/cart/cart_screen.dart
+++ b/lib/cart/cart_screen.dart
@@ -1,4 +1,3 @@
-import 'package:cart_sample/cart/model/billing.dart';
 import 'package:cart_sample/cart/model/menu.dart';
 import 'package:cart_sample/cart/model/store_data.dart';
 import 'package:cart_sample/cart/widget/add_more_widget.dart';
@@ -28,7 +27,7 @@ class _CartScreenState extends State<CartScreen> {
       description: '• 찜 & 리뷰 약속 : 참여. 서비스음료제공',
       price: 18000);
 
-  final _billing = Billing(totalPrice: 18000, deliveryPrice: 3000);
+  final int _deliveryPrice = 3000;
 
   int _counter = 1;
 
@@ -80,12 +79,14 @@ class _CartScreenState extends State<CartScreen> {
               height: 1,
             ),
             AddMoreWidget(),
-            BillingWidget(_billing),
+            BillingWidget(
+              deliveryPrice: _deliveryPrice,
+              itemPrice: _menu.price,
+            ),
           ],
         ),
       ),
-      bottomNavigationBar:
-          _OrderButtonWidget(_billing.deliveryPrice + _billing.totalPrice),
+      bottomNavigationBar: _OrderButtonWidget(_menu.price + _deliveryPrice),
     );
   }
 }

--- a/lib/cart/model/billing.dart
+++ b/lib/cart/model/billing.dart
@@ -1,6 +1,0 @@
-class Billing {
-  final int totalPrice;
-  final int deliveryPrice;
-
-  Billing({required this.totalPrice, required this.deliveryPrice});
-}

--- a/lib/cart/widget/billing_widget.dart
+++ b/lib/cart/widget/billing_widget.dart
@@ -1,3 +1,4 @@
+import 'package:cart_sample/cart/cart_screen.dart';
 import 'package:cart_sample/utils/number.dart';
 import 'package:flutter/material.dart';
 
@@ -11,6 +12,8 @@ class BillingWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    int counter = Counter.of(context).value;
+
     return Container(
       decoration: BoxDecoration(
         color: Colors.white,
@@ -32,7 +35,7 @@ class BillingWidget extends StatelessWidget {
               children: [
                 Text('총 주문금액'),
                 Spacer(),
-                Text(formatPrice(itemPrice)),
+                Text(formatPrice(itemPrice * counter)),
               ],
             ),
           ),
@@ -78,7 +81,7 @@ class BillingWidget extends StatelessWidget {
                 ),
                 Spacer(),
                 Text(
-                  formatPrice(itemPrice + deliveryPrice),
+                  formatPrice((itemPrice * counter) + deliveryPrice),
                   style: TextStyle(
                     fontSize: 16,
                     fontWeight: FontWeight.bold,

--- a/lib/cart/widget/billing_widget.dart
+++ b/lib/cart/widget/billing_widget.dart
@@ -1,11 +1,13 @@
-import 'package:cart_sample/cart/model/billing.dart';
 import 'package:cart_sample/utils/number.dart';
 import 'package:flutter/material.dart';
 
 class BillingWidget extends StatelessWidget {
-  const BillingWidget(this._billing, {Key? key}) : super(key: key);
+  const BillingWidget(
+      {Key? key, required this.deliveryPrice, required this.itemPrice})
+      : super(key: key);
 
-  final Billing _billing;
+  final int deliveryPrice;
+  final int itemPrice;
 
   @override
   Widget build(BuildContext context) {
@@ -30,7 +32,7 @@ class BillingWidget extends StatelessWidget {
               children: [
                 Text('총 주문금액'),
                 Spacer(),
-                Text(formatPrice(_billing.totalPrice)),
+                Text(formatPrice(itemPrice)),
               ],
             ),
           ),
@@ -49,7 +51,7 @@ class BillingWidget extends StatelessWidget {
                 ),
                 Spacer(),
                 Text(
-                  formatPrice(_billing.deliveryPrice),
+                  formatPrice(deliveryPrice),
                   style: TextStyle(
                     fontSize: 16,
                   ),
@@ -76,7 +78,7 @@ class BillingWidget extends StatelessWidget {
                 ),
                 Spacer(),
                 Text(
-                  formatPrice(_billing.totalPrice + _billing.deliveryPrice),
+                  formatPrice(itemPrice + deliveryPrice),
                   style: TextStyle(
                     fontSize: 16,
                     fontWeight: FontWeight.bold,

--- a/lib/cart/widget/menu_widget.dart
+++ b/lib/cart/widget/menu_widget.dart
@@ -1,3 +1,4 @@
+import 'package:cart_sample/cart/cart_screen.dart';
 import 'package:cart_sample/cart/model/menu.dart';
 import 'package:cart_sample/utils/number.dart';
 import 'package:flutter/material.dart';
@@ -9,6 +10,8 @@ class MenuWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    int counter = Counter.of(context).value;
+
     return Container(
       color: Colors.white,
       child: Column(
@@ -78,7 +81,7 @@ class MenuWidget extends StatelessWidget {
           Row(
             mainAxisAlignment: MainAxisAlignment.end,
             children: [
-              _buildCount(),
+              _buildCount(counter: counter),
               SizedBox(
                 width: 20,
               ),
@@ -93,7 +96,7 @@ class MenuWidget extends StatelessWidget {
   }
 }
 
-Widget _buildCount() {
+Widget _buildCount({counter}) {
   return Container(
     decoration: BoxDecoration(
       border: Border.all(color: Colors.grey.withOpacity(0.4)),
@@ -107,7 +110,7 @@ Widget _buildCount() {
           disabledColor: Colors.grey,
           onPressed: null,
         ),
-        Text('1'),
+        Text('$counter'),
         IconButton(
           icon: Icon(Icons.add),
           onPressed: () {},

--- a/lib/cart/widget/menu_widget.dart
+++ b/lib/cart/widget/menu_widget.dart
@@ -4,9 +4,17 @@ import 'package:cart_sample/utils/number.dart';
 import 'package:flutter/material.dart';
 
 class MenuWidget extends StatelessWidget {
-  const MenuWidget(this._menu, {Key? key}) : super(key: key);
+  const MenuWidget(
+      {Key? key,
+      required this.menu,
+      required this.incrementCounter,
+      required this.decrementCounter})
+      : super(key: key);
 
-  final Menu _menu;
+  final Menu menu;
+
+  final Function incrementCounter;
+  final Function decrementCounter;
 
   @override
   Widget build(BuildContext context) {
@@ -22,7 +30,7 @@ class MenuWidget extends StatelessWidget {
                 width: 20,
               ),
               Text(
-                _menu.name,
+                menu.name,
                 style: TextStyle(
                   fontSize: 17,
                   fontWeight: FontWeight.bold,
@@ -54,7 +62,7 @@ class MenuWidget extends StatelessWidget {
                 child: ClipRRect(
                   borderRadius: BorderRadius.circular(12),
                   child: Image.asset(
-                    _menu.imageSrc,
+                    menu.imageSrc,
                     width: 70,
                     height: 70,
                     fit: BoxFit.cover,
@@ -68,12 +76,12 @@ class MenuWidget extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Text(
-                    _menu.description,
+                    menu.description,
                     style: TextStyle(
                       color: Color.fromRGBO(125, 125, 125, 1.0),
                     ),
                   ),
-                  Text(formatPrice(_menu.price)),
+                  Text(formatPrice(menu.price)),
                 ],
               ),
             ],
@@ -81,7 +89,10 @@ class MenuWidget extends StatelessWidget {
           Row(
             mainAxisAlignment: MainAxisAlignment.end,
             children: [
-              _buildCount(counter: counter),
+              _buildCount(
+                  counter: counter,
+                  incrementCounter: incrementCounter,
+                  decrementCounter: decrementCounter),
               SizedBox(
                 width: 20,
               ),
@@ -96,7 +107,7 @@ class MenuWidget extends StatelessWidget {
   }
 }
 
-Widget _buildCount({counter}) {
+Widget _buildCount({counter, incrementCounter, decrementCounter}) {
   return Container(
     decoration: BoxDecoration(
       border: Border.all(color: Colors.grey.withOpacity(0.4)),
@@ -108,12 +119,12 @@ Widget _buildCount({counter}) {
         IconButton(
           icon: Icon(Icons.remove),
           disabledColor: Colors.grey,
-          onPressed: null,
+          onPressed: counter == 1 ? null : decrementCounter,
         ),
         Text('$counter'),
         IconButton(
           icon: Icon(Icons.add),
-          onPressed: () {},
+          onPressed: incrementCounter,
         ),
       ],
     ),

--- a/lib/cart/widget/menu_widget.dart
+++ b/lib/cart/widget/menu_widget.dart
@@ -75,6 +75,15 @@ class MenuWidget extends StatelessWidget {
               ),
             ],
           ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              _buildCount(),
+              SizedBox(
+                width: 20,
+              ),
+            ],
+          ),
           SizedBox(
             height: 20,
           ),
@@ -82,4 +91,28 @@ class MenuWidget extends StatelessWidget {
       ),
     );
   }
+}
+
+Widget _buildCount() {
+  return Container(
+    decoration: BoxDecoration(
+      border: Border.all(color: Colors.grey.withOpacity(0.4)),
+      borderRadius: BorderRadius.circular(6),
+    ),
+    child: Wrap(
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: [
+        IconButton(
+          icon: Icon(Icons.remove),
+          disabledColor: Colors.grey,
+          onPressed: null,
+        ),
+        Text('1'),
+        IconButton(
+          icon: Icon(Icons.add),
+          onPressed: () {},
+        ),
+      ],
+    ),
+  );
 }

--- a/lib/cart/widget/order_button_widget.dart
+++ b/lib/cart/widget/order_button_widget.dart
@@ -2,18 +2,16 @@ part of '../cart_screen.dart';
 
 class _OrderButtonWidget extends StatelessWidget {
   const _OrderButtonWidget(
-      {Key? key,
-      required this.counter,
-      required this.deliveryPrice,
-      required this.itemPrice})
+      {Key? key, required this.deliveryPrice, required this.itemPrice})
       : super(key: key);
 
-  final int counter;
   final int deliveryPrice;
   final int itemPrice;
 
   @override
   Widget build(BuildContext context) {
+    int counter = Counter.of(context).value;
+
     return Container(
       color: Colors.white,
       child: SafeArea(

--- a/lib/cart/widget/order_button_widget.dart
+++ b/lib/cart/widget/order_button_widget.dart
@@ -1,9 +1,16 @@
 part of '../cart_screen.dart';
 
 class _OrderButtonWidget extends StatelessWidget {
-  const _OrderButtonWidget(this._totalPrice, {Key? key}) : super(key: key);
+  const _OrderButtonWidget(
+      {Key? key,
+      required this.counter,
+      required this.deliveryPrice,
+      required this.itemPrice})
+      : super(key: key);
 
-  final int _totalPrice;
+  final int counter;
+  final int deliveryPrice;
+  final int itemPrice;
 
   @override
   Widget build(BuildContext context) {
@@ -29,7 +36,7 @@ class _OrderButtonWidget extends StatelessWidget {
                   ),
                   child: Center(
                     child: Text(
-                      '1',
+                      '$counter',
                       style: TextStyle(
                         color: Color.fromRGBO(44, 191, 188, 1.0),
                         fontWeight: FontWeight.bold,
@@ -41,7 +48,8 @@ class _OrderButtonWidget extends StatelessWidget {
                   width: 7,
                 ),
                 Text(
-                  formatPrice(_totalPrice) + ' 배달 주문하기',
+                  formatPrice((itemPrice * counter) + deliveryPrice) +
+                      ' 배달 주문하기',
                   style: TextStyle(
                     fontSize: 18,
                     fontWeight: FontWeight.bold,


### PR DESCRIPTION
BottomNavigationBar 에서 Counter InheritedWidget을 사용하기 위해서 https://github.com/next-step/flutter-cart-sample/commit/ebd1b1283c0e63fd2243d735dec7cb91e8559924 이렇게 수정하였습니다~

궁금한 부분이 있어서 
1. https://github.com/next-step/flutter-cart-sample/commit/76d824c4041a66af20a377e403ae606f50db098d, (https://github.com/next-step/flutter-cart-sample/commit/76d824c4041a66af20a377e403ae606f50db098d#diff-8348b627f3c28597b4e384235d5f241392de3f6aec6c9dd9e1fe1f304c81b241R90)
2. https://github.com/next-step/flutter-cart-sample/commit/ebd1b1283c0e63fd2243d735dec7cb91e8559924

커밋을 두 번 나누어서 하였는데요~

위젯들이 1depth 로만 이루어져있는 경우에, 
InheritedWidget을 사용하지 않고 1번 커밋처럼 바로 counter 값을 넘겨서 사용해도 될 것 같아서요!

실제 서비스에서는 1depth로만 이루어져있을 때에도 counter 와 같은 값을 InheritedWidget(또는 Provider?)으로 사용하는지?..
Widget depth 가 2개가 넘어가면 InheritedWidget 을 사용하는지..? 요런 컨벤션이 있는지도 궁금하네용 
