### PR TITLE
3단계 Provider로 교체하기

### DIFF
--- a/lib/cart/cart_screen.dart
+++ b/lib/cart/cart_screen.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../utils/number.dart';
+import 'model/counter.dart';
 
 part 'widget/order_button_widget.dart';
 
@@ -46,8 +47,9 @@ class _CartScreenState extends State<CartScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Provider.value(
-        value: _counter,
+    return Provider<Counter>(
+        create: (context) => Counter(),
+        dispose: (context, value) => value.dispose(),
         child: Scaffold(
           backgroundColor: const Color.fromRGBO(246, 246, 246, 1.0),
           appBar: AppBar(

--- a/lib/cart/cart_screen.dart
+++ b/lib/cart/cart_screen.dart
@@ -31,67 +31,47 @@ class _CartScreenState extends State<CartScreen> {
 
   final int _deliveryPrice = 3000;
 
-  int _counter = 1;
-
-  void _incrementCounter() {
-    setState(() {
-      _counter++;
-    });
-  }
-
-  void _decrementCounter() {
-    setState(() {
-      _counter--;
-    });
-  }
-
   @override
   Widget build(BuildContext context) {
-    return Provider<Counter>(
-        create: (context) => Counter(),
-        dispose: (context, value) => value.dispose(),
-        child: Scaffold(
-          backgroundColor: const Color.fromRGBO(246, 246, 246, 1.0),
-          appBar: AppBar(
-            leading: const BackButton(
-              color: Colors.black,
-            ),
-            title: const Text(
-              '장바구니',
-              style: TextStyle(
-                color: Colors.black,
-              ),
-            ),
-            elevation: 0,
-            backgroundColor: Colors.white,
+    return Scaffold(
+      backgroundColor: const Color.fromRGBO(246, 246, 246, 1.0),
+      appBar: AppBar(
+        leading: const BackButton(
+          color: Colors.black,
+        ),
+        title: const Text(
+          '장바구니',
+          style: TextStyle(
+            color: Colors.black,
           ),
-          body: ListView(
-            children: [
-              SizedBox(
-                height: 10,
-              ),
-              StoreNameWidget(_storeData),
-              SizedBox(
-                height: 1,
-              ),
-              MenuWidget(
-                  menu: _menu,
-                  incrementCounter: _incrementCounter,
-                  decrementCounter: _decrementCounter),
-              SizedBox(
-                height: 1,
-              ),
-              AddMoreWidget(),
-              BillingWidget(
-                deliveryPrice: _deliveryPrice,
-                itemPrice: _menu.price,
-              ),
-            ],
+        ),
+        elevation: 0,
+        backgroundColor: Colors.white,
+      ),
+      body: ListView(
+        children: [
+          SizedBox(
+            height: 10,
           ),
-          bottomNavigationBar: _OrderButtonWidget(
+          StoreNameWidget(_storeData),
+          SizedBox(
+            height: 1,
+          ),
+          MenuWidget(menu: _menu),
+          SizedBox(
+            height: 1,
+          ),
+          AddMoreWidget(),
+          BillingWidget(
             deliveryPrice: _deliveryPrice,
             itemPrice: _menu.price,
           ),
-        ));
+        ],
+      ),
+      bottomNavigationBar: _OrderButtonWidget(
+        deliveryPrice: _deliveryPrice,
+        itemPrice: _menu.price,
+      ),
+    );
   }
 }

--- a/lib/cart/cart_screen.dart
+++ b/lib/cart/cart_screen.dart
@@ -5,6 +5,7 @@ import 'package:cart_sample/cart/widget/billing_widget.dart';
 import 'package:cart_sample/cart/widget/menu_widget.dart';
 import 'package:cart_sample/cart/widget/store_name_widget.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
 import '../utils/number.dart';
 
@@ -45,7 +46,7 @@ class _CartScreenState extends State<CartScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Counter(
+    return Provider.value(
         value: _counter,
         child: Scaffold(
           backgroundColor: const Color.fromRGBO(246, 246, 246, 1.0),
@@ -90,27 +91,5 @@ class _CartScreenState extends State<CartScreen> {
             itemPrice: _menu.price,
           ),
         ));
-  }
-}
-
-class Counter extends InheritedWidget {
-  const Counter({
-    Key? key,
-    required this.value,
-    required Widget child,
-  }) : super(key: key, child: child);
-
-  final int value;
-
-  static Counter of(BuildContext context) {
-    final Counter? result =
-        context.dependOnInheritedWidgetOfExactType<Counter>();
-    assert(result != null, 'No Counter found in context');
-    return result!;
-  }
-
-  @override
-  bool updateShouldNotify(Counter old) {
-    return old.value != value;
   }
 }

--- a/lib/cart/model/counter.dart
+++ b/lib/cart/model/counter.dart
@@ -1,11 +1,19 @@
-class Counter {
+import 'package:flutter/foundation.dart';
+
+class Counter extends ChangeNotifier {
   int _count = 1;
 
   get count {
     return _count;
   }
 
-  void dispose() {
-    _count = 1;
+  void increment() {
+    _count++;
+    notifyListeners();
+  }
+
+  void decrement() {
+    _count--;
+    notifyListeners();
   }
 }

--- a/lib/cart/model/counter.dart
+++ b/lib/cart/model/counter.dart
@@ -1,0 +1,11 @@
+class Counter {
+  int _count = 1;
+
+  get count {
+    return _count;
+  }
+
+  void dispose() {
+    _count = 1;
+  }
+}

--- a/lib/cart/widget/billing_widget.dart
+++ b/lib/cart/widget/billing_widget.dart
@@ -1,6 +1,6 @@
-import 'package:cart_sample/cart/cart_screen.dart';
 import 'package:cart_sample/utils/number.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
 class BillingWidget extends StatelessWidget {
   const BillingWidget(
@@ -12,7 +12,7 @@ class BillingWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    int counter = Counter.of(context).value;
+    int counter = Provider.of<int>(context);
 
     return Container(
       decoration: BoxDecoration(

--- a/lib/cart/widget/billing_widget.dart
+++ b/lib/cart/widget/billing_widget.dart
@@ -1,3 +1,4 @@
+import 'package:cart_sample/cart/model/counter.dart';
 import 'package:cart_sample/utils/number.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -12,7 +13,7 @@ class BillingWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    int counter = Provider.of<int>(context);
+    int count = Provider.of<Counter>(context).count;
 
     return Container(
       decoration: BoxDecoration(
@@ -35,7 +36,7 @@ class BillingWidget extends StatelessWidget {
               children: [
                 Text('총 주문금액'),
                 Spacer(),
-                Text(formatPrice(itemPrice * counter)),
+                Text(formatPrice(itemPrice * count)),
               ],
             ),
           ),
@@ -81,7 +82,7 @@ class BillingWidget extends StatelessWidget {
                 ),
                 Spacer(),
                 Text(
-                  formatPrice((itemPrice * counter) + deliveryPrice),
+                  formatPrice((itemPrice * count) + deliveryPrice),
                   style: TextStyle(
                     fontSize: 16,
                     fontWeight: FontWeight.bold,

--- a/lib/cart/widget/billing_widget.dart
+++ b/lib/cart/widget/billing_widget.dart
@@ -1,20 +1,21 @@
-import 'package:cart_sample/cart/model/counter.dart';
 import 'package:cart_sample/utils/number.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../model/counter.dart';
+
 class BillingWidget extends StatelessWidget {
-  const BillingWidget(
-      {Key? key, required this.deliveryPrice, required this.itemPrice})
-      : super(key: key);
+  const BillingWidget({
+    Key? key,
+    required this.deliveryPrice,
+    required this.itemPrice,
+  }) : super(key: key);
 
   final int deliveryPrice;
   final int itemPrice;
 
   @override
   Widget build(BuildContext context) {
-    int count = Provider.of<Counter>(context).count;
-
     return Container(
       decoration: BoxDecoration(
         color: Colors.white,
@@ -36,7 +37,11 @@ class BillingWidget extends StatelessWidget {
               children: [
                 Text('총 주문금액'),
                 Spacer(),
-                Text(formatPrice(itemPrice * count)),
+                Consumer<Counter>(builder: (context, counter, child) {
+                  int count = counter.count;
+
+                  return Text(formatPrice(itemPrice * count));
+                }),
               ],
             ),
           ),
@@ -81,13 +86,17 @@ class BillingWidget extends StatelessWidget {
                   ),
                 ),
                 Spacer(),
-                Text(
-                  formatPrice((itemPrice * count) + deliveryPrice),
-                  style: TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
+                Consumer<Counter>(builder: (context, counter, child) {
+                  int count = counter.count;
+
+                  return Text(
+                    formatPrice((itemPrice * count) + deliveryPrice),
+                    style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  );
+                }),
               ],
             ),
           ),

--- a/lib/cart/widget/counter_widget.dart
+++ b/lib/cart/widget/counter_widget.dart
@@ -3,8 +3,7 @@ part of './menu_widget.dart';
 class _CounterWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    Counter counter = Provider.of<Counter>(context);
-    int count = counter.count;
+    Counter counterModel = Provider.of<Counter>(context, listen: false);
 
     return Container(
       decoration: BoxDecoration(
@@ -14,15 +13,17 @@ class _CounterWidget extends StatelessWidget {
       child: Wrap(
         crossAxisAlignment: WrapCrossAlignment.center,
         children: [
-          IconButton(
-            icon: Icon(Icons.remove),
-            disabledColor: Colors.grey,
-            onPressed: count == 1 ? null : counter.decrement,
-          ),
-          Text('$count'),
+          Consumer<Counter>(
+              builder: (context, counter, child) => IconButton(
+                    icon: Icon(Icons.remove),
+                    disabledColor: Colors.grey,
+                    onPressed: counter.count == 1 ? null : counter.decrement,
+                  )),
+          Consumer<Counter>(
+              builder: (context, counter, child) => Text('${counter.count}')),
           IconButton(
             icon: Icon(Icons.add),
-            onPressed: counter.increment,
+            onPressed: counterModel.increment,
           ),
         ],
       ),

--- a/lib/cart/widget/counter_widget.dart
+++ b/lib/cart/widget/counter_widget.dart
@@ -1,0 +1,31 @@
+part of './menu_widget.dart';
+
+class _CounterWidget extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    Counter counter = Provider.of<Counter>(context);
+    int count = counter.count;
+
+    return Container(
+      decoration: BoxDecoration(
+        border: Border.all(color: Colors.grey.withOpacity(0.4)),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Wrap(
+        crossAxisAlignment: WrapCrossAlignment.center,
+        children: [
+          IconButton(
+            icon: Icon(Icons.remove),
+            disabledColor: Colors.grey,
+            onPressed: count == 1 ? null : counter.decrement,
+          ),
+          Text('$count'),
+          IconButton(
+            icon: Icon(Icons.add),
+            onPressed: counter.increment,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/cart/widget/menu_widget.dart
+++ b/lib/cart/widget/menu_widget.dart
@@ -1,3 +1,4 @@
+import 'package:cart_sample/cart/model/counter.dart';
 import 'package:cart_sample/cart/model/menu.dart';
 import 'package:cart_sample/utils/number.dart';
 import 'package:flutter/material.dart';
@@ -18,7 +19,8 @@ class MenuWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    int counter = Provider.of<int>(context);
+    Counter counter = Provider.of<Counter>(context);
+    int count = counter.count;
 
     return Container(
       color: Colors.white,

--- a/lib/cart/widget/menu_widget.dart
+++ b/lib/cart/widget/menu_widget.dart
@@ -5,17 +5,9 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 class MenuWidget extends StatelessWidget {
-  const MenuWidget(
-      {Key? key,
-      required this.menu,
-      required this.incrementCounter,
-      required this.decrementCounter})
-      : super(key: key);
+  const MenuWidget({Key? key, required this.menu}) : super(key: key);
 
   final Menu menu;
-
-  final Function incrementCounter;
-  final Function decrementCounter;
 
   @override
   Widget build(BuildContext context) {
@@ -92,9 +84,9 @@ class MenuWidget extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.end,
             children: [
               _buildCount(
-                  counter: counter,
-                  incrementCounter: incrementCounter,
-                  decrementCounter: decrementCounter),
+                  count: count,
+                  incrementCounter: counter.increment,
+                  decrementCounter: counter.decrement),
               SizedBox(
                 width: 20,
               ),
@@ -109,7 +101,7 @@ class MenuWidget extends StatelessWidget {
   }
 }
 
-Widget _buildCount({counter, incrementCounter, decrementCounter}) {
+Widget _buildCount({count, incrementCounter, decrementCounter}) {
   return Container(
     decoration: BoxDecoration(
       border: Border.all(color: Colors.grey.withOpacity(0.4)),
@@ -121,9 +113,9 @@ Widget _buildCount({counter, incrementCounter, decrementCounter}) {
         IconButton(
           icon: Icon(Icons.remove),
           disabledColor: Colors.grey,
-          onPressed: counter == 1 ? null : decrementCounter,
+          onPressed: count == 1 ? null : decrementCounter,
         ),
-        Text('$counter'),
+        Text('$count'),
         IconButton(
           icon: Icon(Icons.add),
           onPressed: incrementCounter,

--- a/lib/cart/widget/menu_widget.dart
+++ b/lib/cart/widget/menu_widget.dart
@@ -1,7 +1,7 @@
-import 'package:cart_sample/cart/cart_screen.dart';
 import 'package:cart_sample/cart/model/menu.dart';
 import 'package:cart_sample/utils/number.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
 class MenuWidget extends StatelessWidget {
   const MenuWidget(
@@ -18,7 +18,7 @@ class MenuWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    int counter = Counter.of(context).value;
+    int counter = Provider.of<int>(context);
 
     return Container(
       color: Colors.white,

--- a/lib/cart/widget/menu_widget.dart
+++ b/lib/cart/widget/menu_widget.dart
@@ -4,6 +4,8 @@ import 'package:cart_sample/utils/number.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+part './counter_widget.dart';
+
 class MenuWidget extends StatelessWidget {
   const MenuWidget({Key? key, required this.menu}) : super(key: key);
 
@@ -11,9 +13,6 @@ class MenuWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    Counter counter = Provider.of<Counter>(context);
-    int count = counter.count;
-
     return Container(
       color: Colors.white,
       child: Column(
@@ -83,10 +82,7 @@ class MenuWidget extends StatelessWidget {
           Row(
             mainAxisAlignment: MainAxisAlignment.end,
             children: [
-              _buildCount(
-                  count: count,
-                  incrementCounter: counter.increment,
-                  decrementCounter: counter.decrement),
+              _CounterWidget(),
               SizedBox(
                 width: 20,
               ),
@@ -99,28 +95,4 @@ class MenuWidget extends StatelessWidget {
       ),
     );
   }
-}
-
-Widget _buildCount({count, incrementCounter, decrementCounter}) {
-  return Container(
-    decoration: BoxDecoration(
-      border: Border.all(color: Colors.grey.withOpacity(0.4)),
-      borderRadius: BorderRadius.circular(6),
-    ),
-    child: Wrap(
-      crossAxisAlignment: WrapCrossAlignment.center,
-      children: [
-        IconButton(
-          icon: Icon(Icons.remove),
-          disabledColor: Colors.grey,
-          onPressed: count == 1 ? null : decrementCounter,
-        ),
-        Text('$count'),
-        IconButton(
-          icon: Icon(Icons.add),
-          onPressed: incrementCounter,
-        ),
-      ],
-    ),
-  );
 }

--- a/lib/cart/widget/order_button_widget.dart
+++ b/lib/cart/widget/order_button_widget.dart
@@ -10,7 +10,7 @@ class _OrderButtonWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    int counter = Provider.of<int>(context);
+    int count = Provider.of<Counter>(context).count;
 
     return Container(
       color: Colors.white,
@@ -34,7 +34,7 @@ class _OrderButtonWidget extends StatelessWidget {
                   ),
                   child: Center(
                     child: Text(
-                      '$counter',
+                      '$count',
                       style: TextStyle(
                         color: Color.fromRGBO(44, 191, 188, 1.0),
                         fontWeight: FontWeight.bold,
@@ -46,8 +46,7 @@ class _OrderButtonWidget extends StatelessWidget {
                   width: 7,
                 ),
                 Text(
-                  formatPrice((itemPrice * counter) + deliveryPrice) +
-                      ' 배달 주문하기',
+                  formatPrice((itemPrice * count) + deliveryPrice) + ' 배달 주문하기',
                   style: TextStyle(
                     fontSize: 18,
                     fontWeight: FontWeight.bold,

--- a/lib/cart/widget/order_button_widget.dart
+++ b/lib/cart/widget/order_button_widget.dart
@@ -10,7 +10,7 @@ class _OrderButtonWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    int counter = Counter.of(context).value;
+    int counter = Provider.of<int>(context);
 
     return Container(
       color: Colors.white,

--- a/lib/cart/widget/order_button_widget.dart
+++ b/lib/cart/widget/order_button_widget.dart
@@ -1,17 +1,17 @@
 part of '../cart_screen.dart';
 
 class _OrderButtonWidget extends StatelessWidget {
-  const _OrderButtonWidget(
-      {Key? key, required this.deliveryPrice, required this.itemPrice})
-      : super(key: key);
+  const _OrderButtonWidget({
+    Key? key,
+    required this.deliveryPrice,
+    required this.itemPrice,
+  }) : super(key: key);
 
   final int deliveryPrice;
   final int itemPrice;
 
   @override
   Widget build(BuildContext context) {
-    int count = Provider.of<Counter>(context).count;
-
     return Container(
       color: Colors.white,
       child: SafeArea(
@@ -33,25 +33,33 @@ class _OrderButtonWidget extends StatelessWidget {
                     shape: BoxShape.circle,
                   ),
                   child: Center(
-                    child: Text(
-                      '$count',
-                      style: TextStyle(
-                        color: Color.fromRGBO(44, 191, 188, 1.0),
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
+                    child: Consumer<Counter>(
+                        builder: (context, counter, child) => Text(
+                              '${counter.count}',
+                              style: TextStyle(
+                                color: Color.fromRGBO(44, 191, 188, 1.0),
+                                fontWeight: FontWeight.bold,
+                              ),
+                            )),
                   ),
                 ),
                 SizedBox(
                   width: 7,
                 ),
-                Text(
-                  formatPrice((itemPrice * count) + deliveryPrice) + ' 배달 주문하기',
-                  style: TextStyle(
-                    fontSize: 18,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
+                Consumer<Counter>(
+                  builder: (context, counter, child) {
+                    int count = counter.count;
+
+                    return Text(
+                      formatPrice((itemPrice * count) + deliveryPrice) +
+                          ' 배달 주문하기',
+                      style: TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    );
+                  },
+                )
               ],
             ),
             style: ButtonStyle(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,13 @@
 import 'package:cart_sample/cart/cart_screen.dart';
+import 'package:cart_sample/cart/model/counter.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(
+    ChangeNotifierProvider(
+        create: (context) => Counter(), child: const MyApp()),
+  );
 }
 
 class MyApp extends StatelessWidget {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
   intl: ^0.17.0
+  provider: ^6.0.3
 
 
 dev_dependencies:


### PR DESCRIPTION
- '-' 버튼, 숫자 영역은 count 변경을 감지하고, '+' 버튼은 변경 탐지가 안되게 하려고 `Provider.of<Counter>(context, listen: false)` 로 따로 적용을 하였는데요~
  https://github.com/next-step/flutter-cart-sample/commit/6ef8db27cc903318422fa0f774a1e0255d496fe8
   - 이렇게 한 위젯 안에서도 Consumer 영역을 이렇게 세분화 해서 나눠서 사용하실까요?
   - CounterWidget 은 간단해서 CounterWidget child 영역을 Consumer 로 감싸서 써도 될 것 같기도 해서요!

- `dispose` 는 이런식으로 구현하는게 맞을까요..? https://github.com/next-step/flutter-cart-sample/pull/8/commits/27bc17e71a1b21f0f8075f5cb08462bf77fc2b9a#diff-7674d943448e4fbf42780eae253443a402205e7f4ce48703779457475153b42aR9

- <!> 기존 코드를 그대로 Provider로 교체했을 때 setState 를 사용해도 count가 바뀌지 않을 겁니다. 왜그럴까요...? 그렇다면 어떻게 고치는게 좋을까요?
    - Provider.value 는 value를 바로 넘기지만, Provider 로만 썼을 땐 Model 을 넘기기 때문에 setState 로 동작이 안되는 것이 아닐까합니다!
    - 어떻게 고치는게 좋을까요? => 요게 Provider.value 로 바꿔보는 것이였군요..?!

