### PR TITLE
[Step1] buildMethod를 Widget으로 분리하기

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -45,7 +45,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.cart_sample"
         minSdkVersion 16
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -9,7 +9,8 @@
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
-            android:windowSoftInputMode="adjustResize">
+            android:windowSoftInputMode="adjustResize"
+            android:exported="true">
             <!-- Specifies an Android theme to apply to this Activity as soon as
                  the Android process has started. This theme is visible to the user
                  while the Flutter UI initializes. After that, this theme continues

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.7.20'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:7.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip

--- a/lib/cart_screen.dart
+++ b/lib/cart_screen.dart
@@ -1,6 +1,7 @@
-import 'package:cart_sample/component/menu.dart';
 import 'package:flutter/material.dart';
 
+import 'component/add_more.dart';
+import 'component/menu.dart';
 import 'component/store_name.dart';
 
 class CartScreen extends StatefulWidget {
@@ -50,7 +51,9 @@ class _CartScreenState extends State<CartScreen> {
           SizedBox(
             height: 1,
           ),
-          _buildAddMore(),
+          AddMore(
+            onTap: () => {},
+          ),
           _buildBilling(),
         ],
       ),
@@ -104,34 +107,6 @@ class _CartScreenState extends State<CartScreen> {
               onPressed: () {},
             ),
           ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildAddMore() {
-    return GestureDetector(
-      onTap: () {},
-      child: Container(
-        decoration: BoxDecoration(
-          color: Colors.white,
-          border: Border(
-            bottom: BorderSide(
-              color: Colors.grey.withOpacity(0.3),
-              width: 2,
-            ),
-          ),
-        ),
-        height: 50,
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(Icons.add),
-            Text(
-              '더 담으러 가기',
-              style: TextStyle(fontSize: 17),
-            ),
-          ],
         ),
       ),
     );

--- a/lib/cart_screen.dart
+++ b/lib/cart_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'component/store_name.dart';
+
 class CartScreen extends StatefulWidget {
   const CartScreen({Key? key}) : super(key: key);
 
@@ -30,7 +32,10 @@ class _CartScreenState extends State<CartScreen> {
           SizedBox(
             height: 10,
           ),
-          _buildStoreName(),
+          StoreName(
+            storeImageUrl: 'images/chickenCartoonImage.jpg',
+            storeName: '치킨 잠실점',
+          ),
           SizedBox(
             height: 1,
           ),
@@ -93,35 +98,6 @@ class _CartScreenState extends State<CartScreen> {
             ),
           ),
         ),
-      ),
-    );
-  }
-
-  Widget _buildStoreName() {
-    return Container(
-      color: Colors.white,
-      height: 70,
-      child: Row(
-        children: [
-          SizedBox(
-            width: 20,
-          ),
-          ClipRRect(
-            borderRadius: BorderRadius.circular(12),
-            child: Image.asset(
-              'images/chickenCartoonImage.jpg',
-              width: 35,
-              height: 35,
-            ),
-          ),
-          SizedBox(
-            width: 10,
-          ),
-          Text(
-            '치킨 잠실점',
-            style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
-          )
-        ],
       ),
     );
   }

--- a/lib/cart_screen.dart
+++ b/lib/cart_screen.dart
@@ -1,3 +1,4 @@
+import 'package:cart_sample/component/menu.dart';
 import 'package:flutter/material.dart';
 
 import 'component/store_name.dart';
@@ -39,7 +40,13 @@ class _CartScreenState extends State<CartScreen> {
           SizedBox(
             height: 1,
           ),
-          _buildMenu(),
+          Menu(
+            menuName: '후라이드 치킨',
+            menuImageUrl: 'images/chicken.png',
+            menuDescription: '• 찜 & 리뷰 약속 : 참여. 서비스음료제공',
+            menuPrice: 17500,
+            onCancel: () => {},
+          ),
           SizedBox(
             height: 1,
           ),
@@ -98,81 +105,6 @@ class _CartScreenState extends State<CartScreen> {
             ),
           ),
         ),
-      ),
-    );
-  }
-
-  Widget _buildMenu() {
-    return Container(
-      color: Colors.white,
-      child: Column(
-        children: [
-          Row(
-            children: [
-              SizedBox(
-                width: 20,
-              ),
-              Text(
-                '후라이드 치킨',
-                style: TextStyle(
-                  fontSize: 17,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-              Spacer(),
-              IconButton(
-                icon: Icon(
-                  Icons.close,
-                  color: Colors.grey,
-                ),
-                onPressed: () {},
-              ),
-            ],
-          ),
-          Row(
-            children: [
-              SizedBox(
-                width: 20,
-              ),
-              Container(
-                decoration: BoxDecoration(
-                  border: Border.all(
-                    color: Colors.grey.withOpacity(0.3),
-                    width: 1,
-                  ),
-                  borderRadius: BorderRadius.circular(12),
-                ),
-                child: ClipRRect(
-                  borderRadius: BorderRadius.circular(12),
-                  child: Image.asset(
-                    'images/chicken.png',
-                    width: 70,
-                    height: 70,
-                    fit: BoxFit.cover,
-                  ),
-                ),
-              ),
-              SizedBox(
-                width: 10,
-              ),
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    '• 찜 & 리뷰 약속 : 참여. 서비스음료제공',
-                    style: TextStyle(
-                      color: Color.fromRGBO(125, 125, 125, 1.0),
-                    ),
-                  ),
-                  Text('18,000원'),
-                ],
-              ),
-            ],
-          ),
-          SizedBox(
-            height: 20,
-          ),
-        ],
       ),
     );
   }

--- a/lib/cart_screen.dart
+++ b/lib/cart_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'component/add_more.dart';
+import 'component/billing.dart';
 import 'component/menu.dart';
 import 'component/store_name.dart';
 
@@ -54,7 +55,10 @@ class _CartScreenState extends State<CartScreen> {
           AddMore(
             onTap: () => {},
           ),
-          _buildBilling(),
+          Billing(
+            totalAmount: 17500,
+            deliveryFee: 3000,
+          ),
         ],
       ),
       bottomNavigationBar: Container(
@@ -108,91 +112,6 @@ class _CartScreenState extends State<CartScreen> {
             ),
           ),
         ),
-      ),
-    );
-  }
-
-  Widget _buildBilling() {
-    return Container(
-      decoration: BoxDecoration(
-        color: Colors.white,
-        border: Border(
-          bottom: BorderSide(
-            color: Colors.grey.withOpacity(0.3),
-            width: 2,
-          ),
-        ),
-      ),
-      child: Column(
-        children: [
-          SizedBox(
-            height: 20,
-          ),
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 20),
-            child: Row(
-              children: [
-                Text('총 주문금액'),
-                Spacer(),
-                Text('18,000원'),
-              ],
-            ),
-          ),
-          SizedBox(
-            height: 10,
-          ),
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 20),
-            child: Row(
-              children: [
-                Text(
-                  '배탈팁',
-                  style: TextStyle(
-                    fontSize: 16,
-                  ),
-                ),
-                Spacer(),
-                Text(
-                  '3,000원',
-                  style: TextStyle(
-                    fontSize: 16,
-                  ),
-                ),
-              ],
-            ),
-          ),
-          Padding(
-            padding: const EdgeInsets.all(20),
-            child: Divider(
-              color: Colors.grey,
-            ),
-          ),
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 20),
-            child: Row(
-              children: [
-                Text(
-                  '결제예정금액',
-                  style: TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-                Spacer(),
-                Text(
-                  '21,000원',
-                  style: TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-              ],
-            ),
-          ),
-          SizedBox(
-            height: 20,
-          ),
-        ],
       ),
     );
   }

--- a/lib/cart_screen.dart
+++ b/lib/cart_screen.dart
@@ -1,3 +1,4 @@
+import 'package:cart_sample/component/order_button.dart';
 import 'package:flutter/material.dart';
 
 import 'component/add_more.dart';
@@ -16,103 +17,55 @@ class _CartScreenState extends State<CartScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: const Color.fromRGBO(246, 246, 246, 1.0),
-      appBar: AppBar(
-        leading: const BackButton(
-          color: Colors.black,
-        ),
-        title: const Text(
-          '장바구니',
-          style: TextStyle(
+        backgroundColor: const Color.fromRGBO(246, 246, 246, 1.0),
+        appBar: AppBar(
+          leading: const BackButton(
             color: Colors.black,
           ),
-        ),
-        elevation: 0,
-        backgroundColor: Colors.white,
-      ),
-      body: ListView(
-        children: [
-          SizedBox(
-            height: 10,
-          ),
-          StoreName(
-            storeImageUrl: 'images/chickenCartoonImage.jpg',
-            storeName: '치킨 잠실점',
-          ),
-          SizedBox(
-            height: 1,
-          ),
-          Menu(
-            menuName: '후라이드 치킨',
-            menuImageUrl: 'images/chicken.png',
-            menuDescription: '• 찜 & 리뷰 약속 : 참여. 서비스음료제공',
-            menuPrice: 17500,
-            onCancel: () => {},
-          ),
-          SizedBox(
-            height: 1,
-          ),
-          AddMore(
-            onTap: () => {},
-          ),
-          Billing(
-            totalAmount: 17500,
-            deliveryFee: 3000,
-          ),
-        ],
-      ),
-      bottomNavigationBar: Container(
-        color: Colors.white,
-        child: SafeArea(
-          child: Container(
-            height: 65,
-            padding: const EdgeInsets.symmetric(
-              horizontal: 20,
-              vertical: 10,
-            ),
-            child: ElevatedButton(
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Container(
-                    width: 25,
-                    height: 25,
-                    decoration: BoxDecoration(
-                      color: Colors.white,
-                      shape: BoxShape.circle,
-                    ),
-                    child: Center(
-                      child: Text(
-                        '1',
-                        style: TextStyle(
-                          color: Color.fromRGBO(44, 191, 188, 1.0),
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
-                    ),
-                  ),
-                  SizedBox(
-                    width: 7,
-                  ),
-                  Text(
-                    '21,000원 배달 주문하기',
-                    style: TextStyle(
-                      fontSize: 18,
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                ],
-              ),
-              style: ButtonStyle(
-                backgroundColor: MaterialStateProperty.all(
-                  Color.fromRGBO(44, 191, 188, 1.0),
-                ),
-              ),
-              onPressed: () {},
+          title: const Text(
+            '장바구니',
+            style: TextStyle(
+              color: Colors.black,
             ),
           ),
+          elevation: 0,
+          backgroundColor: Colors.white,
         ),
-      ),
-    );
+        body: ListView(
+          children: [
+            SizedBox(
+              height: 10,
+            ),
+            StoreName(
+              storeImageUrl: 'images/chickenCartoonImage.jpg',
+              storeName: '치킨 잠실점',
+            ),
+            SizedBox(
+              height: 1,
+            ),
+            Menu(
+              menuName: '후라이드 치킨',
+              menuImageUrl: 'images/chicken.png',
+              menuDescription: '• 찜 & 리뷰 약속 : 참여. 서비스음료제공',
+              menuPrice: 17500,
+              onCancel: () => {},
+            ),
+            SizedBox(
+              height: 1,
+            ),
+            AddMore(
+              onTap: () => {},
+            ),
+            Billing(
+              totalAmount: 17500,
+              deliveryFee: 3000,
+            ),
+          ],
+        ),
+        bottomNavigationBar: OrderButton(
+          numberOfMenu: 1,
+          totalPayAmount: 20500,
+          onPressed: () => {},
+        ));
   }
 }

--- a/lib/component/add_more.dart
+++ b/lib/component/add_more.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+
+class AddMore extends StatelessWidget {
+  final VoidCallback _onTap;
+
+  const AddMore({
+    Key? key,
+    required VoidCallback onTap,
+  })  : _onTap = onTap,
+        super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: _onTap,
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          border: Border(
+            bottom: BorderSide(
+              color: Colors.grey.withOpacity(0.3),
+              width: 2,
+            ),
+          ),
+        ),
+        height: 50,
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.add),
+            Text(
+              '더 담으러 가기',
+              style: TextStyle(fontSize: 17),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/component/billing.dart
+++ b/lib/component/billing.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+
+import 'utils/money_format.dart';
+
+class Billing extends StatelessWidget {
+  final int _totalAmount;
+  final int _deliveryFee;
+
+  const Billing({
+    Key? key,
+    required int totalAmount,
+    required int deliveryFee,
+  })  : _totalAmount = totalAmount,
+        _deliveryFee = deliveryFee,
+        super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.white,
+        border: Border(
+          bottom: BorderSide(
+            color: Colors.grey.withOpacity(0.3),
+            width: 2,
+          ),
+        ),
+      ),
+      child: Column(
+        children: [
+          SizedBox(
+            height: 20,
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 20),
+            child: Row(
+              children: [
+                Text('총 주문금액'),
+                Spacer(),
+                Text('${_totalAmount.toMoneyFormatString()}원'),
+              ],
+            ),
+          ),
+          SizedBox(
+            height: 10,
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 20),
+            child: Row(
+              children: [
+                Text(
+                  '배탈팁',
+                  style: TextStyle(
+                    fontSize: 16,
+                  ),
+                ),
+                Spacer(),
+                Text(
+                  '${_deliveryFee.toMoneyFormatString()}원',
+                  style: TextStyle(
+                    fontSize: 16,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(20),
+            child: Divider(
+              color: Colors.grey,
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 20),
+            child: Row(
+              children: [
+                Text(
+                  '결제예정금액',
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                Spacer(),
+                Text(
+                  '${(_totalAmount + _deliveryFee).toMoneyFormatString()}원',
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          SizedBox(
+            height: 20,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/component/menu.dart
+++ b/lib/component/menu.dart
@@ -1,0 +1,100 @@
+import 'package:cart_sample/component/utils/money_format.dart';
+import 'package:flutter/material.dart';
+
+class Menu extends StatelessWidget {
+  final String _menuName;
+  final String _menuImageUrl;
+  final String _menuDescription;
+  final int _menuPrice;
+  final VoidCallback _onCancel;
+
+  const Menu({
+    Key? key,
+    required String menuName,
+    required String menuImageUrl,
+    required String menuDescription,
+    required int menuPrice,
+    required VoidCallback onCancel,
+  })  : _menuName = menuName,
+        _menuImageUrl = menuImageUrl,
+        _menuDescription = menuDescription,
+        _menuPrice = menuPrice,
+        _onCancel = onCancel,
+        super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: Colors.white,
+      child: Column(
+        children: [
+          Row(
+            children: [
+              SizedBox(
+                width: 20,
+              ),
+              Text(
+                _menuName,
+                style: TextStyle(
+                  fontSize: 17,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              Spacer(),
+              IconButton(
+                icon: Icon(
+                  Icons.close,
+                  color: Colors.grey,
+                ),
+                onPressed: _onCancel,
+              ),
+            ],
+          ),
+          Row(
+            children: [
+              SizedBox(
+                width: 20,
+              ),
+              Container(
+                decoration: BoxDecoration(
+                  border: Border.all(
+                    color: Colors.grey.withOpacity(0.3),
+                    width: 1,
+                  ),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(12),
+                  child: Image.asset(
+                    _menuImageUrl,
+                    width: 70,
+                    height: 70,
+                    fit: BoxFit.cover,
+                  ),
+                ),
+              ),
+              SizedBox(
+                width: 10,
+              ),
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    _menuDescription,
+                    style: TextStyle(
+                      color: Color.fromRGBO(125, 125, 125, 1.0),
+                    ),
+                  ),
+                  Text('${_menuPrice.toMoneyFormatString()}원'),
+                ],
+              ),
+            ],
+          ),
+          SizedBox(
+            height: 20,
+          ),
+        ],
+      ),
+    );;
+  }
+}

--- a/lib/component/order_button.dart
+++ b/lib/component/order_button.dart
@@ -1,0 +1,75 @@
+import 'package:cart_sample/component/utils/money_format.dart';
+import 'package:flutter/material.dart';
+
+class OrderButton extends StatelessWidget {
+  final int _numberOfMenu;
+  final int _totalPayAmount;
+  final VoidCallback _onPressed;
+
+  const OrderButton({
+    Key? key,
+    required int numberOfMenu,
+    required int totalPayAmount,
+    required VoidCallback onPressed,
+  })
+      : _numberOfMenu = numberOfMenu,
+        _totalPayAmount = totalPayAmount,
+        _onPressed = onPressed,
+        super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: Colors.white,
+      child: SafeArea(
+        child: Container(
+          height: 65,
+          padding: const EdgeInsets.symmetric(
+            horizontal: 20,
+            vertical: 10,
+          ),
+          child: ElevatedButton(
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Container(
+                  width: 25,
+                  height: 25,
+                  decoration: BoxDecoration(
+                    color: Colors.white,
+                    shape: BoxShape.circle,
+                  ),
+                  child: Center(
+                    child: Text(
+                      _numberOfMenu.toString(),
+                      style: TextStyle(
+                        color: Color.fromRGBO(44, 191, 188, 1.0),
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                ),
+                SizedBox(
+                  width: 7,
+                ),
+                Text(
+                  '${_totalPayAmount.toMoneyFormatString()}원 배달 주문하기',
+                  style: TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ],
+            ),
+            style: ButtonStyle(
+              backgroundColor: MaterialStateProperty.all(
+                Color.fromRGBO(44, 191, 188, 1.0),
+              ),
+            ),
+            onPressed: _onPressed,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/component/store_name.dart
+++ b/lib/component/store_name.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+class StoreName extends StatelessWidget {
+  final String _storeName;
+  final String _storeImageUrl;
+
+  const StoreName({
+    Key? key,
+    required String storeName,
+    required String storeImageUrl,
+  })  : _storeName = storeName,
+        _storeImageUrl = storeImageUrl,
+        super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: Colors.white,
+      height: 70,
+      child: Row(
+        children: [
+          SizedBox(
+            width: 20,
+          ),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(12),
+            child: Image.asset(
+              _storeImageUrl,
+              width: 35,
+              height: 35,
+            ),
+          ),
+          SizedBox(
+            width: 10,
+          ),
+          Text(
+            _storeName,
+            style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/component/utils/money_format.dart
+++ b/lib/component/utils/money_format.dart
@@ -1,0 +1,12 @@
+import 'package:intl/intl.dart';
+
+final _simpleCurrencyFormat = NumberFormat.currency(
+  locale: 'ko_KR',
+  symbol: '',
+);
+
+extension MoneyFormatString on int {
+  String toMoneyFormatString() {
+    return _simpleCurrencyFormat.format(this);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
+  intl: ^0.17.0
 
 
 dev_dependencies:


### PR DESCRIPTION
안녕하세요 리뷰어님 :)
저는 주니어 안드로이드 개발자예요! 플러터로 iOS 앱을 빠르게 프로토 타입을 만들 수 있게 되고 싶어 이번 강좌를 수강했어요.
안드로이드 컴포즈와 친해지는 중이라 선언형 UI가 눈에는 조금 익숙하지만 직접 써보는 것은 처음이에요.

선언형 UI에 대해, 그리고 dart나 flutter의 스타일에 익숙하지 않아서, 보이는 부분이 있으시면 많이 짚어주세요 😀

kotlin에 너무 익숙해서 생성자로 넣는 값을 모두 캡슐화 했는데, flutter 내부 구현들을 보면 내부의 값을 거의 감추지 않더라구요? set을 하지 않아도 되니 외부에 공개한 것일까요? 캡슐화를 하지 않는 이유가 궁금해졌어요.
(메뉴 이름, 가격 등등)

그리고 도움이 필요한 게 하나 있는데요!
AppBar도 class로 나누고 싶어서 다른 위젯들과 같이 StatelessWidget를 활용해서 분리해보려 했는데 아래 같은 에러가 발생하네요 ㅠㅠ 이런 경우에는 어떻게 해결하면 좋을까요? 감이 잘 잡히지 않아서, 검색할 수 있는 키워드라도 부탁드립니다.

![image](https://user-images.githubusercontent.com/44341119/199533482-9c5d47a8-8f11-46ed-9a96-9bc0bcaad131.png)


1단계 미션 잘 부탁드립니다~ 😊


