### PR TITLE
🚀 2단계 InheritedWidget 사용하기

### DIFF
--- a/lib/cart_screen.dart
+++ b/lib/cart_screen.dart
@@ -4,6 +4,7 @@ import 'models/payment.dart';
 import 'models/product.dart';
 import 'models/shop.dart';
 import 'utils/formatter.dart';
+import 'widgets/cart_item_counter.dart';
 import 'widgets/payment_info.dart';
 import 'widgets/shop_info.dart';
 

--- a/lib/widgets/cart_item.dart
+++ b/lib/widgets/cart_item.dart
@@ -81,7 +81,7 @@ class CartItem extends StatelessWidget {
           Row(
             mainAxisAlignment: MainAxisAlignment.end,
             children: [
-              _buildCount(),
+              CartItemCounter(),
               SizedBox(
                 width: 20,
               ),
@@ -89,32 +89,6 @@ class CartItem extends StatelessWidget {
           ),
           SizedBox(
             height: 20,
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildCount() {
-    return Container(
-      decoration: BoxDecoration(
-        border: Border.all(
-          color: Colors.grey.withOpacity(0.4),
-        ),
-        borderRadius: BorderRadius.circular(6),
-      ),
-      child: Wrap(
-        crossAxisAlignment: WrapCrossAlignment.center,
-        children: [
-          IconButton(
-            icon: Icon(Icons.remove),
-            disabledColor: Colors.grey,
-            onPressed: () {},
-          ),
-          Text('1'),
-          IconButton(
-            icon: Icon(Icons.add),
-            onPressed: () {},
           ),
         ],
       ),

--- a/lib/widgets/cart_item.dart
+++ b/lib/widgets/cart_item.dart
@@ -78,8 +78,43 @@ class CartItem extends StatelessWidget {
               ),
             ],
           ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              _buildCount(),
+              SizedBox(
+                width: 20,
+              ),
+            ],
+          ),
           SizedBox(
             height: 20,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCount() {
+    return Container(
+      decoration: BoxDecoration(
+        border: Border.all(
+          color: Colors.grey.withOpacity(0.4),
+        ),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Wrap(
+        crossAxisAlignment: WrapCrossAlignment.center,
+        children: [
+          IconButton(
+            icon: Icon(Icons.remove),
+            disabledColor: Colors.grey,
+            onPressed: () {},
+          ),
+          Text('1'),
+          IconButton(
+            icon: Icon(Icons.add),
+            onPressed: () {},
           ),
         ],
       ),

--- a/lib/widgets/cart_item_counter.dart
+++ b/lib/widgets/cart_item_counter.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+class CartItemCounter extends StatelessWidget {
+  const CartItemCounter({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        border: Border.all(
+          color: Colors.grey.withOpacity(0.4),
+        ),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Wrap(
+        crossAxisAlignment: WrapCrossAlignment.center,
+        children: [
+          IconButton(
+            icon: Icon(Icons.remove),
+            disabledColor: Colors.grey,
+            onPressed: () {},
+          ),
+          Text('1'),
+          IconButton(
+            icon: Icon(Icons.add),
+            onPressed: () {},
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/counter.dart
+++ b/lib/widgets/counter.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+class Counter extends InheritedWidget {
+  const Counter({
+    Key? key,
+    required this.value,
+    required Widget child,
+  }) : super(key: key, child: child);
+
+  final int value;
+
+  static Counter of(BuildContext context) {
+    final Counter? result =
+        context.dependOnInheritedWidgetOfExactType<Counter>();
+    assert(result != null, 'No Counter found in context');
+    return result!;
+  }
+
+  @override
+  bool updateShouldNotify(Counter old) {
+    return old.value != value;
+  }
+}


### PR DESCRIPTION
### 요구사항

> 숫자 값을 전달하지 않고, `InheritedWidget` 사용

- [ ] count가 1일 경우, ➖ 버튼 비활성
- [ ] ➕ 버튼을 클릭할 경우, count 증가
- [ ] '총 주문금액'은 상품의 가격과 개수를 곱한 금액으로 변경
- [ ] '결제예정금액' 및 '주문하기 버튼'의 가격과 개수도 변경